### PR TITLE
Set form state only after mount

### DIFF
--- a/packages/yeager-core/components/Form.tsx
+++ b/packages/yeager-core/components/Form.tsx
@@ -111,6 +111,10 @@ export default class Form extends React.Component<Props, State> {
   };
 
   componentDidMount() {
+    // Ideally we don’t want to do `setState` in `cDM`, but rather assign it to
+    // `this.state` directly. But `this.reconcileFormState` logic can only be
+    // after mount, so we intentionally call it here and cause a double-render.
+    // Not ideal, but that’ll do for now.
     this.setState({ formState: this.reconcileFormState(this.props) }, () => {
       const populatedFormData = populateFormData(this.state.formState, this.props.formData);
       this.props.updateFormData(populatedFormData);

--- a/packages/yeager-core/components/Form.tsx
+++ b/packages/yeager-core/components/Form.tsx
@@ -110,17 +110,11 @@ export default class Form extends React.Component<Props, State> {
     }
   };
 
-  constructor(props: Props) {
-    super(props);
-    this.setState({ formState: this.reconcileFormState(props) });
-  }
-
   componentDidMount() {
-    const populatedFormData = populateFormData(
-      this.state.formState,
-      this.props.formData,
-    );
-    this.props.updateFormData(populatedFormData);
+    this.setState({ formState: this.reconcileFormState(this.props) }, () => {
+      const populatedFormData = populateFormData(this.state.formState, this.props.formData);
+      this.props.updateFormData(populatedFormData);
+    });
   }
 
   componentWillReceiveProps(next: Props) {


### PR DESCRIPTION
`this.setState` call in `constructor` results in React complaining that we cannot set the state of a component that has yet to mount. Because this `setState` call fails, on initial mount the form has no fields; they only appear if props change and `cWRP` gets triggered.

Ideally we don’t want to do `setState` in `cDM`, but rather assign it to `this.state` directly. But it seems to me that `this.reconcileFormState` logic can only be performed after mount, so short of dangerously rearchitecting it, I intentionally call it here in `cDM` and cause a double-render. Not ideal, but that’ll do for now!